### PR TITLE
Fixed example missing brackets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ struct ModalBarcodeGenerator: View {
     @State var dataString = "Hello Carbode"
     @State var barcodeType = CBBarcodeView.BarcodeType.qrCode
     @State var rotate = CBBarcodeView.Orientation.up
-    
+
     var body: some View {
         var body: some View {
             VStack {

--- a/README.md
+++ b/README.md
@@ -192,14 +192,15 @@ struct ModalBarcodeGenerator: View {
     @State var dataString = "Hello Carbode"
     @State var barcodeType = CBBarcodeView.BarcodeType.qrCode
     @State var rotate = CBBarcodeView.Orientation.up
-
+    
     var body: some View {
         var body: some View {
-        VStack {
-            CBBarcodeView(data: $dataString,
-                barcodeType: $barcodeType,
-                orientation: $rotate)
-                .frame(minWidth: 0, maxWidth: .infinity, minHeight: 400, maxHeight: 400, alignment: .topLeading)
+            VStack {
+                CBBarcodeView(data: $dataString,
+                              barcodeType: $barcodeType,
+                              orientation: $rotate)
+                    .frame(minWidth: 0, maxWidth: .infinity, minHeight: 400, maxHeight: 400, alignment: .topLeading)
+            }
         }
     }
 }


### PR DESCRIPTION
Example code was missing a "}" and couldn't compile when copy-pasted