### PR TITLE
Add isActive flag to CBScanner

### DIFF
--- a/Sources/CarBode/CBScanner.swift
+++ b/Sources/CarBode/CBScanner.swift
@@ -32,6 +32,8 @@ public struct CBScanner: UIViewRepresentable {
     
     @Binding
     public var mockBarCode: BarcodeData
+
+    public let isActive: Bool
     
     public var onFound: OnFound?
     public var onDraw: OnDraw?
@@ -41,6 +43,7 @@ public struct CBScanner: UIViewRepresentable {
          scanInterval: Binding<Double> = .constant(3.0),
          cameraPosition: Binding<AVCaptureDevice.Position> = .constant(.back),
          mockBarCode: Binding<BarcodeData> = .constant(BarcodeData(value: "barcode value", type: .qr)),
+         isActive: Bool = true,
          onFound: @escaping OnFound,
          onDraw: OnDraw? = nil
     ) {
@@ -49,6 +52,7 @@ public struct CBScanner: UIViewRepresentable {
         _scanInterval = scanInterval
         _cameraPosition = cameraPosition
         _mockBarCode = mockBarCode
+        self.isActive = isActive
         self.onFound = onFound
         self.onDraw = onDraw
     }
@@ -77,7 +81,15 @@ public struct CBScanner: UIViewRepresentable {
         
         uiView.setContentHuggingPriority(.defaultHigh, for: .vertical)
         uiView.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        uiView.updateCameraView()
+
+        if isActive {
+            if !(uiView.session?.isRunning ?? false) {
+                uiView.session?.startRunning()
+            }
+            uiView.updateCameraView()
+        } else {
+            uiView.session?.stopRunning()
+        }
     }
 
 }


### PR DESCRIPTION
In order to control whether `CBScanner`'s capture session is active or not, a simple Bool flag is added.
Note that no `Binding` is needed since two-way control probably doesn't make sense (if two-way control is needed, then a Binding would indeed be needed instead).

Fixes #40