### PR TITLE
Resolve issue 51 - Starting scanner in landscape

### DIFF
--- a/Sources/CarBode/CameraPreview.swift
+++ b/Sources/CarBode/CameraPreview.swift
@@ -174,6 +174,7 @@ public class CameraPreview: UIView {
                         self.layer.addSublayer(previewLayer)
                         
                         self.previewLayer = previewLayer
+                        self.updateCameraView()
                     }
                 }
                 


### PR DESCRIPTION
Resets the cameraView on initiation to resolve issue where starting in landscape has the wrong orientation until rotated to portrait and back to landscape.