### PR TITLE
Fixes main thread call to startRunning() and corner calculations

### DIFF
--- a/Sources/CarBode/CBScanner.swift
+++ b/Sources/CarBode/CBScanner.swift
@@ -88,12 +88,13 @@ public struct CBScanner: UIViewRepresentable {
 
         if isActive {
             if !(uiView.session?.isRunning ?? false) {
-                uiView.session?.startRunning()
+                DispatchQueue.global().async {
+                    uiView.session?.startRunning()
+                }
             }
             uiView.updateCameraView()
         } else {
             uiView.session?.stopRunning()
         }
     }
-
 }

--- a/Sources/CarBode/CameraPreview.swift
+++ b/Sources/CarBode/CameraPreview.swift
@@ -279,9 +279,8 @@ extension CameraPreview: AVCaptureMetadataOutputObjectsDelegate {
             
 #if !targetEnvironment(simulator)
             var corners: [CGPoint] = []
-            readableObject.corners.forEach {
-                let point = convertToViewCoordinate(point: $0)
-                corners.append(point)
+            if let transformed = previewLayer?.transformedMetadataObject(for: readableObject) as? AVMetadataMachineReadableCodeObject {
+                corners = transformed.corners
             }
             let frame = BarcodeFrame(corners: corners, cameraPreviewView: self)
             onDraw?(frame)
@@ -312,66 +311,6 @@ extension CameraPreview: AVCaptureMetadataOutputObjectsDelegate {
 
 
 extension CameraPreview {
-    func convertToViewCoordinate(point: CGPoint) -> CGPoint {
-        let orientation = getVideoOrientation()
-        
-        var pointX: CGFloat = 0
-        var pointY: CGFloat = 0
-        
-        switch orientation {
-        case .portrait:
-            let scale = self.bounds.width / 720
-            let previewWidth = 720 * scale
-            let previewHeight = 1280 * scale
-            
-            let croppedFrameY = previewHeight / 2 - self.bounds.height / 2
-            
-            let x = 1.0 - point.y
-            let y = point.x
-            
-            pointX = x * previewWidth
-            pointY = (y * previewHeight) - croppedFrameY
-        case .landscapeRight:
-            let scale = self.bounds.width / 1280
-            let previewWidth = 1280 * scale
-            let previewHeight = 720 * scale
-            
-            let croppedFrameY = previewHeight / 2 - self.bounds.height / 2
-            
-            pointX = point.x * previewWidth
-            pointY = (point.y * previewHeight) - croppedFrameY
-        case .landscapeLeft:
-            let scale = self.bounds.width / 1280
-            let previewWidth = 1280 * scale
-            let previewHeight = 720 * scale
-            
-            let croppedFrameY = previewHeight / 2 - self.bounds.height / 2
-            
-            let x = 1.0 - point.x
-            let y = 1.0 - point.y
-            
-            pointX = x * previewWidth
-            pointY = (y * previewHeight) - croppedFrameY
-        case .portraitUpsideDown:
-            let scale = self.bounds.width / 720
-            let previewWidth = 720 * scale
-            let previewHeight = 1280 * scale
-            
-            let croppedFrameY = previewHeight / 2 - self.bounds.height / 2
-            
-            let x = 1.0 - point.y
-            let y = point.x
-            
-            pointX = x * previewWidth
-            pointY = (y * previewHeight) - croppedFrameY
-        @unknown default:
-            pointX = 0
-            pointY = 0
-        }
-        
-        return CGPoint(x: pointX, y: pointY)
-    }
-    
     @objc func removeBarcodeFrame() {
         shapeLayer?.removeFromSuperlayer()
     }


### PR DESCRIPTION
This PR addresses two issues I found when using the package.

### startRunning() being called from the main thread
`startRunning()` should be called from the background

### Corner calculation
I found an issue when calculating the corners on CameraPreview when using ignoresSafeArea() on the CBScanner. Also by using `transformedMetadataObject` there is no need for the `convertToViewCoordinate` method.