### PR TITLE
Fixes a bug when CBScanner is initialized with the torch light on

### DIFF
--- a/Sources/CarBode/CBScanner.swift
+++ b/Sources/CarBode/CBScanner.swift
@@ -68,6 +68,7 @@ public struct CBScanner: UIViewRepresentable {
         view.onFound = onFound
         view.onDraw = onDraw
         view.mockBarCode = mockBarCode
+        view.torchLightIsOn = torchLightIsOn
         return view
     }
 
@@ -77,7 +78,9 @@ public struct CBScanner: UIViewRepresentable {
 
     public func updateUIView(_ uiView: CameraPreview, context: UIViewRepresentableContext<CBScanner>) {
 
-        uiView.setTorchLight(isOn: torchLightIsOn)
+        if uiView.session?.isRunning == true && uiView.selectedCamera != nil {
+            uiView.setTorchLight(isOn: torchLightIsOn)
+        }
         uiView.zoom(to: zoom)
         uiView.setCamera(position: cameraPosition)
         uiView.scanInterval = scanInterval

--- a/Sources/CarBode/CameraPreview.swift
+++ b/Sources/CarBode/CameraPreview.swift
@@ -129,18 +129,12 @@ public class CameraPreview: UIView,ObservableObject {
     }
     
     func setTorchLight(isOn: Bool) {
-        
-        if torchLightIsOn == isOn { return }
-        
-        torchLightIsOn = isOn
         if let camera = selectedCamera {
             if camera.hasTorch {
+                if isOn == (camera.torchMode == .on) { return }
+
                 try? camera.lockForConfiguration()
-                if isOn {
-                    camera.torchMode = .on
-                } else {
-                    camera.torchMode = .off
-                }
+                camera.torchMode = isOn ? .on : .off
                 camera.unlockForConfiguration()
             }
         }
@@ -207,6 +201,9 @@ public class CameraPreview: UIView,ObservableObject {
                         self.previewLayer = previewLayer
                         self.updateCameraView()
                         self.zoom(to: self.currentZoom)
+                        if self.torchLightIsOn {
+                            self.setTorchLight(isOn: true)
+                        }
                     }
                 }
                 


### PR DESCRIPTION
There was an issue when `CBScanner` was initialized with `torchLightIsOn` on `true`. Given that the value was initially `true` we need to compare agains the camera status instead of the previous value of the flag.